### PR TITLE
Capture CodedUI logging

### DIFF
--- a/Winium.StoreApps.CodedUITestProject/Automator.cs
+++ b/Winium.StoreApps.CodedUITestProject/Automator.cs
@@ -2,6 +2,7 @@
 {
     #region
 
+    using System;
     using System.Net;
     using System.Reflection;
 
@@ -34,7 +35,7 @@
 
         #region Constructors and Destructors
 
-        public Automator()
+        private Automator()
         {
             this.socketServer = new SocketServer(this.RequestHandler);
 
@@ -50,7 +51,15 @@
 
         #region Public Properties
 
-        public string Session { get; set; }
+        private string Session { get; set; }
+
+        public bool Running
+        {
+            get
+            {
+                return this.socketServer.IsServiceActive;
+            } 
+        }
 
         #endregion
 
@@ -73,6 +82,12 @@
         private CommandResponse RequestHandler(string uri, string content)
         {
             var command = JsonConvert.DeserializeObject<Command>(content);
+
+            if (command.Name.Equals(DriverCommand.Quit))
+            {
+                this.socketServer.ShouldStopAfterResponse = true;
+                return CommandResponse.Create(HttpStatusCode.OK, null);
+            }
 
             var executor = this.commandsExecutorsDispatcher.GetExecutor<CommandExecutorBase>(command.Name);
 

--- a/Winium.StoreApps.CodedUITestProject/CodedUiTestLoop.cs
+++ b/Winium.StoreApps.CodedUITestProject/CodedUiTestLoop.cs
@@ -19,10 +19,11 @@
         public void CodedUiTestMethod1()
         {
             Automator.Instance.Start();
-            while (true)
+            while (Automator.Instance.Running)
             {
                 Task.Delay(TimeSpan.FromMilliseconds(50)).Wait();
             }
+            Automator.Instance.Stop();
         }
 
         #endregion

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/ClickElementExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/ClickElementExecutor.cs
@@ -2,10 +2,12 @@
 {
     #region
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class ClickElementExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/CloseExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/CloseExecutor.cs
@@ -2,10 +2,12 @@
 {
     #region
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class CloseExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindChildElementExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindChildElementExecutor.cs
@@ -1,8 +1,10 @@
 ﻿namespace Winium.StoreApps.CodedUITestProject.CommandExecutors
 {
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.CodedUITestProject.CommandExecutors.Helpers;
     using Winium.StoreApps.Common;
 
+    [UsedImplicitly]
     public class FindChildElementExecutor : CommandExecutorBase
     {
         protected override string DoImpl()

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindChildElementsExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindChildElementsExecutor.cs
@@ -2,9 +2,11 @@
 {
     using System.Linq;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.CodedUITestProject.CommandExecutors.Helpers;
     using Winium.StoreApps.Common;
 
+    [UsedImplicitly]
     public class FindChildElementsExecutor : CommandExecutorBase
     {
         protected override string DoImpl()

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindElementExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindElementExecutor.cs
@@ -2,9 +2,11 @@
 {
     using System.Windows.Automation;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.CodedUITestProject.CommandExecutors.Helpers;
     using Winium.StoreApps.Common;
 
+    [UsedImplicitly]
     public class FindElementExecutor : CommandExecutorBase
     {
         protected override string DoImpl()

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindElementsExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/FindElementsExecutor.cs
@@ -3,9 +3,11 @@
     using System.Linq;
     using System.Windows.Automation;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.CodedUITestProject.CommandExecutors.Helpers;
     using Winium.StoreApps.Common;
 
+    [UsedImplicitly]
     public class FindElementsExecutor : CommandExecutorBase
     {
         protected override string DoImpl()

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetElementAttributeExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetElementAttributeExecutor.cs
@@ -2,8 +2,10 @@
 {
     using Newtonsoft.Json.Linq;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
+    [UsedImplicitly]
     public class GetElementAttributeExecutor : CommandExecutorBase
     {
         protected override string DoImpl()

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetElementTextExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetElementTextExecutor.cs
@@ -2,10 +2,12 @@
 {
     #region
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class GetElementTextExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetPageSourceExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetPageSourceExecutor.cs
@@ -4,8 +4,11 @@
 
     using System.Windows.Automation;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
+
     #endregion
 
+    [UsedImplicitly]
     public class GetPageSourceExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetSupportedAutomationExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/GetSupportedAutomationExecutor.cs
@@ -2,13 +2,16 @@
 {
     #region
 
+    using System.Globalization;
     using System.Text;
     using System.Windows.Automation;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class GetSupportedAutomationExecutor : CommandExecutorBase
     {
         #region Methods
@@ -23,7 +26,7 @@
             foreach (var automationProperty in properties)
             {
                 var value = element.GetCurrentPropertyValue(automationProperty);
-                msg.AppendFormat("{0}: {1}\n", automationProperty.ProgrammaticName, value);
+                msg.AppendFormat(CultureInfo.InvariantCulture, "{0}: {1}\n", automationProperty.ProgrammaticName, value);
             }
 
             return msg.ToString();

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/SendKeysToElementExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/SendKeysToElementExecutor.cs
@@ -4,10 +4,12 @@
 
     using System.Linq;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class SendKeysToElementExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/SwitchToWindowExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/SwitchToWindowExecutor.cs
@@ -2,10 +2,12 @@
 {
     #region
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class SwitchToWindowExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/CommandExecutors/TouchFlickExecutor.cs
+++ b/Winium.StoreApps.CodedUITestProject/CommandExecutors/TouchFlickExecutor.cs
@@ -9,10 +9,12 @@
     using Microsoft.VisualStudio.TestTools.UITest.Input;
     using Microsoft.VisualStudio.TestTools.UITesting;
 
+    using Winium.StoreApps.CodedUITestProject.Annotations;
     using Winium.StoreApps.Common;
 
     #endregion
 
+    [UsedImplicitly]
     public class TouchFlickExecutor : CommandExecutorBase
     {
         #region Methods

--- a/Winium.StoreApps.CodedUITestProject/ElementsRegistry.cs
+++ b/Winium.StoreApps.CodedUITestProject/ElementsRegistry.cs
@@ -92,7 +92,7 @@
         {
             Interlocked.Increment(ref safeInstanceCount);
 
-            var registeredKey = string.Format(
+            var registeredKey = string.Format(CultureInfo.InvariantCulture,
                 "{0}-{1}", 
                 element.GetHashCode(), 
                 safeInstanceCount.ToString(string.Empty, CultureInfo.InvariantCulture));
@@ -106,7 +106,7 @@
             var sb = new StringBuilder();
             foreach (var pair in this.registeredElements)
             {
-                sb.AppendFormat("{0} -> [{1}]\n", pair.Key, pair.Value);
+                sb.AppendFormat(CultureInfo.InvariantCulture, "{0} -> [{1}]\n", pair.Key, pair.Value);
             }
 
             return sb.ToString();

--- a/Winium.StoreApps.CodedUITestProject/Properties/Annotations.cs
+++ b/Winium.StoreApps.CodedUITestProject/Properties/Annotations.cs
@@ -1,0 +1,614 @@
+﻿using System;
+
+#pragma warning disable 1591
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
+
+namespace Winium.StoreApps.CodedUITestProject.Annotations
+{
+  /// <summary>
+  /// Indicates that the value of the marked element could be <c>null</c> sometimes,
+  /// so the check for <c>null</c> is necessary before its usage
+  /// </summary>
+  /// <example><code>
+  /// [CanBeNull] public object Test() { return null; }
+  /// public void UseTest() {
+  ///   var p = Test();
+  ///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Parameter |
+    AttributeTargets.Property | AttributeTargets.Delegate |
+    AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+  public sealed class CanBeNullAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the value of the marked element could never be <c>null</c>
+  /// </summary>
+  /// <example><code>
+  /// [NotNull] public object Foo() {
+  ///   return null; // Warning: Possible 'null' assignment
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Method | AttributeTargets.Parameter |
+    AttributeTargets.Property | AttributeTargets.Delegate |
+    AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+  public sealed class NotNullAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the marked method builds string by format pattern and (optional) arguments.
+  /// Parameter, which contains format string, should be given in constructor. The format string
+  /// should be in <see cref="string.Format(IFormatProvider,string,object[])"/>-like form
+  /// </summary>
+  /// <example><code>
+  /// [StringFormatMethod("message")]
+  /// public void ShowError(string message, params object[] args) { /* do something */ }
+  /// public void Foo() {
+  ///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Constructor | AttributeTargets.Method,
+    AllowMultiple = false, Inherited = true)]
+  public sealed class StringFormatMethodAttribute : Attribute
+  {
+    /// <param name="formatParameterName">
+    /// Specifies which parameter of an annotated method should be treated as format-string
+    /// </param>
+    public StringFormatMethodAttribute(string formatParameterName)
+    {
+      FormatParameterName = formatParameterName;
+    }
+
+    public string FormatParameterName { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the function argument should be string literal and match one
+  /// of the parameters of the caller function. For example, ReSharper annotates
+  /// the parameter of <see cref="System.ArgumentNullException"/>
+  /// </summary>
+  /// <example><code>
+  /// public void Foo(string param) {
+  ///   if (param == null)
+  ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+  public sealed class InvokerParameterNameAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that the method is contained in a type that implements
+  /// <see cref="System.ComponentModel.INotifyPropertyChanged"/> interface
+  /// and this method is used to notify that some property value changed
+  /// </summary>
+  /// <remarks>
+  /// The method should be non-static and conform to one of the supported signatures:
+  /// <list>
+  /// <item><c>NotifyChanged(string)</c></item>
+  /// <item><c>NotifyChanged(params string[])</c></item>
+  /// <item><c>NotifyChanged{T}(Expression{Func{T}})</c></item>
+  /// <item><c>NotifyChanged{T,U}(Expression{Func{T,U}})</c></item>
+  /// <item><c>SetProperty{T}(ref T, T, string)</c></item>
+  /// </list>
+  /// </remarks>
+  /// <example><code>
+  /// public class Foo : INotifyPropertyChanged {
+  ///   public event PropertyChangedEventHandler PropertyChanged;
+  ///   [NotifyPropertyChangedInvocator]
+  ///   protected virtual void NotifyChanged(string propertyName) { ... }
+  ///
+  ///   private string _name;
+  ///   public string Name {
+  ///     get { return _name; }
+  ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
+  ///   }
+  /// }
+  /// </code>
+  /// Examples of generated notifications:
+  /// <list>
+  /// <item><c>NotifyChanged("Property")</c></item>
+  /// <item><c>NotifyChanged(() =&gt; Property)</c></item>
+  /// <item><c>NotifyChanged((VM x) =&gt; x.Property)</c></item>
+  /// <item><c>SetProperty(ref myField, value, "Property")</c></item>
+  /// </list>
+  /// </example>
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+  public sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
+  {
+    public NotifyPropertyChangedInvocatorAttribute() { }
+    public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+    {
+      ParameterName = parameterName;
+    }
+
+    public string ParameterName { get; private set; }
+  }
+
+  /// <summary>
+  /// Describes dependency between method input and output
+  /// </summary>
+  /// <syntax>
+  /// <p>Function Definition Table syntax:</p>
+  /// <list>
+  /// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+  /// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+  /// <item>Input    ::= ParameterName: Value [, Input]*</item>
+  /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+  /// <item>Value    ::= true | false | null | notnull | canbenull</item>
+  /// </list>
+  /// If method has single input parameter, it's name could be omitted.<br/>
+  /// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same)
+  /// for method output means that the methos doesn't return normally.<br/>
+  /// <c>canbenull</c> annotation is only applicable for output parameters.<br/>
+  /// You can use multiple <c>[ContractAnnotation]</c> for each FDT row,
+  /// or use single attribute with rows separated by semicolon.<br/>
+  /// </syntax>
+  /// <examples><list>
+  /// <item><code>
+  /// [ContractAnnotation("=> halt")]
+  /// public void TerminationMethod()
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("halt &lt;= condition: false")]
+  /// public void Assert(bool condition, string text) // regular assertion method
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("s:null => true")]
+  /// public bool IsNullOrEmpty(string s) // string.IsNullOrEmpty()
+  /// </code></item>
+  /// <item><code>
+  /// // A method that returns null if the parameter is null, and not null if the parameter is not null
+  /// [ContractAnnotation("null => null; notnull => notnull")]
+  /// public object Transform(object data) 
+  /// </code></item>
+  /// <item><code>
+  /// [ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")]
+  /// public bool TryParse(string s, out Person result)
+  /// </code></item>
+  /// </list></examples>
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+  public sealed class ContractAnnotationAttribute : Attribute
+  {
+    public ContractAnnotationAttribute([NotNull] string contract)
+      : this(contract, false) { }
+
+    public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+    {
+      Contract = contract;
+      ForceFullStates = forceFullStates;
+    }
+
+    public string Contract { get; private set; }
+    public bool ForceFullStates { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that marked element should be localized or not
+  /// </summary>
+  /// <example><code>
+  /// [LocalizationRequiredAttribute(true)]
+  /// public class Foo {
+  ///   private string str = "my string"; // Warning: Localizable string
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+  public sealed class LocalizationRequiredAttribute : Attribute
+  {
+    public LocalizationRequiredAttribute() : this(true) { }
+    public LocalizationRequiredAttribute(bool required)
+    {
+      Required = required;
+    }
+
+    public bool Required { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the value of the marked type (or its derivatives)
+  /// cannot be compared using '==' or '!=' operators and <c>Equals()</c>
+  /// should be used instead. However, using '==' or '!=' for comparison
+  /// with <c>null</c> is always permitted.
+  /// </summary>
+  /// <example><code>
+  /// [CannotApplyEqualityOperator]
+  /// class NoEquality { }
+  /// class UsesNoEquality {
+  ///   public void Test() {
+  ///     var ca1 = new NoEquality();
+  ///     var ca2 = new NoEquality();
+  ///     if (ca1 != null) { // OK
+  ///       bool condition = ca1 == ca2; // Warning
+  ///     }
+  ///   }
+  /// }
+  /// </code></example>
+  [AttributeUsage(
+    AttributeTargets.Interface | AttributeTargets.Class |
+    AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
+  public sealed class CannotApplyEqualityOperatorAttribute : Attribute { }
+
+  /// <summary>
+  /// When applied to a target attribute, specifies a requirement for any type marked
+  /// with the target attribute to implement or inherit specific type or types.
+  /// </summary>
+  /// <example><code>
+  /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
+  /// public class ComponentAttribute : Attribute { }
+  /// [Component] // ComponentAttribute requires implementing IComponent interface
+  /// public class MyComponent : IComponent { }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+  [BaseTypeRequired(typeof(Attribute))]
+  public sealed class BaseTypeRequiredAttribute : Attribute
+  {
+    public BaseTypeRequiredAttribute([NotNull] Type baseType)
+    {
+      BaseType = baseType;
+    }
+
+    [NotNull] public Type BaseType { get; private set; }
+  }
+
+  /// <summary>
+  /// Indicates that the marked symbol is used implicitly
+  /// (e.g. via reflection, in external library), so this symbol
+  /// will not be marked as unused (as well as by other usage inspections)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
+  public sealed class UsedImplicitlyAttribute : Attribute
+  {
+    public UsedImplicitlyAttribute()
+      : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+    public UsedImplicitlyAttribute(ImplicitUseKindFlags useKindFlags)
+      : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+    public UsedImplicitlyAttribute(ImplicitUseTargetFlags targetFlags)
+      : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+    public UsedImplicitlyAttribute(
+      ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+    {
+      UseKindFlags = useKindFlags;
+      TargetFlags = targetFlags;
+    }
+
+    public ImplicitUseKindFlags UseKindFlags { get; private set; }
+    public ImplicitUseTargetFlags TargetFlags { get; private set; }
+  }
+
+  /// <summary>
+  /// Should be used on attributes and causes ReSharper
+  /// to not mark symbols marked with such attributes as unused
+  /// (as well as by other usage inspections)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+  public sealed class MeansImplicitUseAttribute : Attribute
+  {
+    public MeansImplicitUseAttribute() 
+      : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+      : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+      : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+    public MeansImplicitUseAttribute(
+      ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+    {
+      UseKindFlags = useKindFlags;
+      TargetFlags = targetFlags;
+    }
+
+    [UsedImplicitly] public ImplicitUseKindFlags UseKindFlags { get; private set; }
+    [UsedImplicitly] public ImplicitUseTargetFlags TargetFlags { get; private set; }
+  }
+  
+  [Flags]
+  public enum ImplicitUseKindFlags
+  {
+    Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+    /// <summary>Only entity marked with attribute considered used</summary>
+    Access = 1,
+    /// <summary>Indicates implicit assignment to a member</summary>
+    Assign = 2,
+    /// <summary>
+    /// Indicates implicit instantiation of a type with fixed constructor signature.
+    /// That means any unused constructor parameters won't be reported as such.
+    /// </summary>
+    InstantiatedWithFixedConstructorSignature = 4,
+    /// <summary>Indicates implicit instantiation of a type</summary>
+    InstantiatedNoFixedConstructorSignature = 8,
+  }
+
+  /// <summary>
+  /// Specify what is considered used implicitly
+  /// when marked with <see cref="MeansImplicitUseAttribute"/>
+  /// or <see cref="UsedImplicitlyAttribute"/>
+  /// </summary>
+  [Flags]
+  public enum ImplicitUseTargetFlags
+  {
+    Default = Itself,
+    Itself = 1,
+    /// <summary>Members of entity marked with attribute are considered used</summary>
+    Members = 2,
+    /// <summary>Entity marked with attribute and all its members considered used</summary>
+    WithMembers = Itself | Members
+  }
+
+  /// <summary>
+  /// This attribute is intended to mark publicly available API
+  /// which should not be removed and so is treated as used
+  /// </summary>
+  [MeansImplicitUse]
+  public sealed class PublicAPIAttribute : Attribute
+  {
+    public PublicAPIAttribute() { }
+    public PublicAPIAttribute([NotNull] string comment)
+    {
+      Comment = comment;
+    }
+
+    [NotNull] public string Comment { get; private set; }
+  }
+
+  /// <summary>
+  /// Tells code analysis engine if the parameter is completely handled
+  /// when the invoked method is on stack. If the parameter is a delegate,
+  /// indicates that delegate is executed while the method is executed.
+  /// If the parameter is an enumerable, indicates that it is enumerated
+  /// while the method is executed
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter, Inherited = true)]
+  public sealed class InstantHandleAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that a method does not make any observable state changes.
+  /// The same as <c>System.Diagnostics.Contracts.PureAttribute</c>
+  /// </summary>
+  /// <example><code>
+  /// [Pure] private int Multiply(int x, int y) { return x * y; }
+  /// public void Foo() {
+  ///   const int a = 2, b = 2;
+  ///   Multiply(a, b); // Waring: Return value of pure method is not used
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+  public sealed class PureAttribute : Attribute { }
+
+  /// <summary>
+  /// Indicates that a parameter is a path to a file or a folder
+  /// within a web project. Path can be relative or absolute,
+  /// starting from web root (~)
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public class PathReferenceAttribute : Attribute
+  {
+    public PathReferenceAttribute() { }
+    public PathReferenceAttribute([PathReference] string basePath)
+    {
+      BasePath = basePath;
+    }
+
+    [NotNull] public string BasePath { get; private set; }
+  }
+
+  // ASP.NET MVC attributes
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcAreaMasterLocationFormatAttribute : Attribute
+  {
+    public AspMvcAreaMasterLocationFormatAttribute(string format) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcAreaPartialViewLocationFormatAttribute : Attribute
+  {
+    public AspMvcAreaPartialViewLocationFormatAttribute(string format) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcAreaViewLocationFormatAttribute : Attribute
+  {
+    public AspMvcAreaViewLocationFormatAttribute(string format) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcMasterLocationFormatAttribute : Attribute
+  {
+    public AspMvcMasterLocationFormatAttribute(string format) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcPartialViewLocationFormatAttribute : Attribute
+  {
+    public AspMvcPartialViewLocationFormatAttribute(string format) { }
+  }
+
+  [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+  public sealed class AspMvcViewLocationFormatAttribute : Attribute
+  {
+    public AspMvcViewLocationFormatAttribute(string format) { }
+  }
+  
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+  /// is an MVC action. If applied to a method, the MVC action name is calculated
+  /// implicitly from the context. Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcActionAttribute : Attribute
+  {
+    public AspMvcActionAttribute() { }
+    public AspMvcActionAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull] public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC area.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcAreaAttribute : PathReferenceAttribute
+  {
+    public AspMvcAreaAttribute() { }
+    public AspMvcAreaAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull] public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that
+  /// the parameter is an MVC controller. If applied to a method,
+  /// the MVC controller name is calculated implicitly from the context.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.Mvc.Html.ChildActionExtensions.RenderAction(HtmlHelper, String, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcControllerAttribute : Attribute
+  {
+    public AspMvcControllerAttribute() { }
+    public AspMvcControllerAttribute([NotNull] string anonymousProperty)
+    {
+      AnonymousProperty = anonymousProperty;
+    }
+
+    [NotNull] public string AnonymousProperty { get; private set; }
+  }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC Master.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(String, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcMasterAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC model type.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(String, Object)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcModelTypeAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that
+  /// the parameter is an MVC partial view. If applied to a method,
+  /// the MVC partial view name is calculated implicitly from the context.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.RenderPartialExtensions.RenderPartial(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcPartialViewAttribute : PathReferenceAttribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Allows disabling all inspections
+  /// for MVC views within a class or a method.
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+  public sealed class AspMvcSupressViewErrorAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcDisplayTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC editor template.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Html.EditorExtensions.EditorForModel(HtmlHelper, String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcEditorTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. Indicates that a parameter is an MVC template.
+  /// Use this attribute for custom wrappers similar to
+  /// <c>System.ComponentModel.DataAnnotations.UIHintAttribute(System.String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter)]
+  public sealed class AspMvcTemplateAttribute : Attribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. If applied to a parameter, indicates that the parameter
+  /// is an MVC view. If applied to a method, the MVC view name is calculated implicitly
+  /// from the context. Use this attribute for custom wrappers similar to
+  /// <c>System.Web.Mvc.Controller.View(Object)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+  public sealed class AspMvcViewAttribute : PathReferenceAttribute { }
+
+  /// <summary>
+  /// ASP.NET MVC attribute. When applied to a parameter of an attribute,
+  /// indicates that this parameter is an MVC action name
+  /// </summary>
+  /// <example><code>
+  /// [ActionName("Foo")]
+  /// public ActionResult Login(string returnUrl) {
+  ///   ViewBag.ReturnUrl = Url.Action("Foo"); // OK
+  ///   return RedirectToAction("Bar"); // Error: Cannot resolve action
+  /// }
+  /// </code></example>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+  public sealed class AspMvcActionSelectorAttribute : Attribute { }
+
+  [AttributeUsage(
+    AttributeTargets.Parameter | AttributeTargets.Property |
+    AttributeTargets.Field, Inherited = true)]
+  public sealed class HtmlElementAttributesAttribute : Attribute
+  {
+    public HtmlElementAttributesAttribute() { }
+    public HtmlElementAttributesAttribute([NotNull] string name)
+    {
+      Name = name;
+    }
+
+    [NotNull] public string Name { get; private set; }
+  }
+
+  [AttributeUsage(
+    AttributeTargets.Parameter | AttributeTargets.Field |
+    AttributeTargets.Property, Inherited = true)]
+  public sealed class HtmlAttributeValueAttribute : Attribute
+  {
+    public HtmlAttributeValueAttribute([NotNull] string name)
+    {
+      Name = name;
+    }
+
+    [NotNull] public string Name { get; private set; }
+  }
+
+  // Razor attributes
+
+  /// <summary>
+  /// Razor attribute. Indicates that a parameter or a method is a Razor section.
+  /// Use this attribute for custom wrappers similar to 
+  /// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method, Inherited = true)]
+  public sealed class RazorSectionAttribute : Attribute { }
+}

--- a/Winium.StoreApps.CodedUITestProject/Winium.StoreApps.CodedUITestProject.csproj
+++ b/Winium.StoreApps.CodedUITestProject/Winium.StoreApps.CodedUITestProject.csproj
@@ -61,6 +61,7 @@
     <Compile Include="CommandExecutors\Helpers\By.cs" />
     <Compile Include="CommandExecutors\TouchFlickExecutor.cs" />
     <Compile Include="ElementsRegistry.cs" />
+    <Compile Include="Properties\Annotations.cs" />
     <Compile Include="SocketServer.cs" />
     <Compile Include="AcceptedRequest.cs" />
     <Compile Include="Automator.cs" />

--- a/Winium.StoreApps.CodedUi.sln.DotSettings
+++ b/Winium.StoreApps.CodedUi.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Winium_002EStoreApps_002ECodedUITestProject_002EAnnotations/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Winium.StoreApps.Driver/CommandExecutors/NewSessionExecutor.cs
+++ b/Winium.StoreApps.Driver/CommandExecutors/NewSessionExecutor.cs
@@ -15,7 +15,9 @@
 
         protected override string DoImpl()
         {
-            var session = SessionsManager.CreateSession();
+            this.Session = SessionsManager.CreateSession();
+
+            var session = this.Session;
             var serializedCapability =
                 JsonConvert.SerializeObject(this.ExecutedCommand.Parameters["desiredCapabilities"]);
             session.ActualCapabilities = Capabilities.CapabilitiesFromJsonString(serializedCapability);
@@ -24,7 +26,8 @@
             session.Deployer = new Deployer(
                 session.ActualCapabilities.DeviceName, 
                 session.ActualCapabilities.DeviceIpAddress,
-                session.ActualCapabilities.Locale);
+                session.ActualCapabilities.Locale,
+                session.ActualCapabilities.DebugCaptureLogs);
 
             if (!session.ActualCapabilities.DebugCodedUi)
             {

--- a/Winium.StoreApps.Driver/CommandExecutors/QuitExecutor.cs
+++ b/Winium.StoreApps.Driver/CommandExecutors/QuitExecutor.cs
@@ -8,6 +8,7 @@
         {
             if (!this.Session.ActualCapabilities.DebugCodedUi)
             {
+                this.Session.CommandForwarder.ForwardCommand(this.ExecutedCommand);
                 this.Session.Deployer.Close();
             }
 

--- a/Winium.StoreApps.Driver/CommandExecutors/QuitExecutor.cs
+++ b/Winium.StoreApps.Driver/CommandExecutors/QuitExecutor.cs
@@ -1,16 +1,14 @@
 ﻿namespace Winium.StoreApps.Driver.CommandExecutors
 {
+    using Winium.StoreApps.Driver.Helpers;
+
     internal class QuitExecutor : CommandExecutorBase
     {
         #region Methods
 
         protected override string DoImpl()
         {
-            if (!this.Session.ActualCapabilities.DebugCodedUi)
-            {
-                this.Session.CommandForwarder.ForwardCommand(this.ExecutedCommand);
-                this.Session.Deployer.Close();
-            }
+            SessionsManager.CloseSession(this.Session.SessionId);
 
             return this.JsonResponse();
         }

--- a/Winium.StoreApps.Driver/Helpers/Capabilities.cs
+++ b/Winium.StoreApps.Driver/Helpers/Capabilities.cs
@@ -18,9 +18,10 @@
             this.App = string.Empty;
             this.DeviceName = string.Empty;
             this.InnerPort = 9998;
-            this.TakesScreenshot = true;
+            this.DeviceIpAddress = "localhost";
             this.DebugCodedUi = false;
             this.Locale = CultureInfo.CurrentCulture.Name;
+            this.DebugCaptureLogs = false;
         }
 
         #endregion
@@ -37,25 +38,25 @@
         }
 
         [JsonProperty("app")]
-        public string App { get; set; }
+        public string App { get; private set; }
 
         [JsonProperty("deviceName")]
-        public string DeviceName { get; set; }
+        public string DeviceName { get; private set; }
 
         [JsonProperty("deviceIpAddress")]
-        public string DeviceIpAddress { get; set; }
+        public string DeviceIpAddress { get; private set; }
 
         [JsonProperty("innerPort")]
-        public int InnerPort { get; set; }
+        public int InnerPort { get; private set; }
 
         [JsonProperty("locale")]
-        public string Locale { get; set; }
-
-        [JsonProperty("takesScreenshot")]
-        public bool TakesScreenshot { get; set; }
+        public string Locale { get; private set; }
 
         [JsonProperty("debugCodedUI")]
-        public bool DebugCodedUi { get; set; }
+        public bool DebugCodedUi { get; private set; }
+
+        [JsonProperty("debugCaptureLogs")]
+        public bool DebugCaptureLogs { get; private set; }
 
         #endregion
 
@@ -75,11 +76,6 @@
                 });
 
             return capabilities;
-        }
-
-        public string CapabilitiesToJsonString()
-        {
-            return JsonConvert.SerializeObject(this);
         }
 
         #endregion

--- a/Winium.StoreApps.Driver/Helpers/Deployer.cs
+++ b/Winium.StoreApps.Driver/Helpers/Deployer.cs
@@ -2,9 +2,8 @@
 {
     #region
 
-    using System.Diagnostics;
+    using System;
     using System.Globalization;
-    using System.IO;
     using System.Linq;
 
     using Microsoft.Phone.Tools.Deploy;
@@ -15,43 +14,48 @@
 
     #endregion
 
-    public class Deployer
+    public class Deployer : IDisposable
     {
-        #region Constants
-
-        private const string CodedUiTestDllPath =
-            @"..\..\..\Winium.StoreApps.CodedUITestProject\bin\Debug\Winium.StoreApps.CodedUITestProject.dll";
-
-        #endregion
-
         #region Fields
 
-        private Process codedUiTestProcess;
+        private readonly bool captureCodedUiLogs;
 
         private ConnectableDevice connectableDevice;
 
         private IDevice device;
 
+        private bool disposed;
+
+        private VsTestConsoleWrapper testConsole;
+
         #endregion
 
         #region Constructors and Destructors
 
-        public Deployer(string desiredDeviceName, string ipAddress, string localeTag)
+        public Deployer(string desiredDeviceName, string ipAddress, string localeTag, bool captureCodedUiLogs)
         {
             this.IpAddress = ipAddress;
 
             this.Culture = new CultureInfo(localeTag);
 
             this.Connect(desiredDeviceName);
+
+            this.captureCodedUiLogs = captureCodedUiLogs;
         }
 
         #endregion
 
         #region Public Properties
 
-        public CultureInfo Culture { get; private set; }
+        public string IpAddress { get; private set; }
 
-        public string DeviceName
+        #endregion
+
+        #region Properties
+
+        private CultureInfo Culture { get; set; }
+
+        private string DeviceName
         {
             get
             {
@@ -59,47 +63,20 @@
             }
         }
 
-        public string IpAddress { get; private set; }
-
         #endregion
 
         #region Public Methods and Operators
 
-        public void Close()
-        {
-            // this.codedUiTestProcess.CloseMainWindow();
-            // this.codedUiTestProcess.Close();
-            this.device.Disconnect();
-        }
-
         public void DeployCodedUiTestServer()
         {
-            var pathToVsTestconsole = System.Configuration.ConfigurationManager.AppSettings["VsTestConsolePath"];
+            this.testConsole = new VsTestConsoleWrapper(this.DeviceName);
+            this.testConsole.DeployCodedUiTestServer(this.captureCodedUiLogs);
+        }
 
-            var runSettingsDoc = new RunSettings(this.DeviceName);
-            var tempFilePath = Path.GetTempFileName();
-
-            runSettingsDoc.XmlDoc.Save(tempFilePath);
-
-            // TODO We should generate run settings to specify device/emulator
-            var codedUiTestLoopPsi = new ProcessStartInfo
-                                         {
-                                             UseShellExecute = false, 
-                                             RedirectStandardError = true, 
-                                             RedirectStandardOutput = true, 
-                                             FileName = pathToVsTestconsole, 
-                                             Arguments =
-                                                 string.Format(
-                                                     "\"{0}\" /Settings:\"{1}\" /logger:trx", 
-                                                     CodedUiTestDllPath, 
-                                                     tempFilePath)
-                                         };
-
-            this.codedUiTestProcess = new Process { StartInfo = codedUiTestLoopPsi };
-            this.codedUiTestProcess.OutputDataReceived += CaptureOutput;
-            this.codedUiTestProcess.ErrorDataReceived += CaptureOutput;
-            this.codedUiTestProcess.Start();
-            this.codedUiTestProcess.BeginOutputReadLine();
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         public void Install(string appxPath)
@@ -118,9 +95,25 @@
 
         #region Methods
 
-        private static void CaptureOutput(object sender, DataReceivedEventArgs args)
+        protected virtual void Dispose(bool disposing)
         {
-            Logger.Debug("CodedUI: {0}", args.Data);
+            if (this.disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                if (this.testConsole != null)
+                {
+                    this.testConsole.Dispose();
+                }
+            }
+
+            // Free any unmanaged objects here. 
+            this.device.Disconnect();
+
+            this.disposed = true;
         }
 
         private void Connect(string desiredDeviceName)

--- a/Winium.StoreApps.Driver/Helpers/Session.cs
+++ b/Winium.StoreApps.Driver/Helpers/Session.cs
@@ -1,5 +1,7 @@
 ﻿namespace Winium.StoreApps.Driver.Helpers
 {
+    using Winium.StoreApps.Common;
+
     internal class Session
     {
         #region Constructors and Destructors
@@ -22,5 +24,17 @@
         public string SessionId { get; private set; }
 
         #endregion
+
+        public void Close()
+        {
+            if (this.ActualCapabilities.DebugCodedUi)
+            {
+                return;
+            }
+
+            var quitCommand = new Command(DriverCommand.Quit);
+            this.CommandForwarder.ForwardCommand(quitCommand);
+            this.Deployer.Dispose();
+        }
     }
 }

--- a/Winium.StoreApps.Driver/Helpers/SessionsManager.cs
+++ b/Winium.StoreApps.Driver/Helpers/SessionsManager.cs
@@ -1,16 +1,10 @@
 ﻿namespace Winium.StoreApps.Driver.Helpers
 {
-    #region
-
-    using System.Collections.Generic;
-
-    #endregion
-
     internal static class SessionsManager
     {
         #region Static Fields
 
-        private static readonly Dictionary<string, Session> Sessions;
+        private static Session currentSession;
 
         #endregion
 
@@ -18,8 +12,7 @@
 
         static SessionsManager()
         {
-            Sessions = new Dictionary<string, Session>();
-            Sessions["AwesomeSession"] = new Session("AwesomeSession");
+            currentSession = null;
         }
 
         #endregion
@@ -28,22 +21,33 @@
 
         public static void CloseSession(string sessionId)
         {
-            var session = GetSessionbyId(sessionId);
-            if (null != session)
+            if (currentSession == null)
             {
-                // sessions.Remove(sessionId);
+                return;
             }
+
+            Logger.Info("Closing current session {0}.", sessionId);
+            currentSession.Close();
+            currentSession = null;
         }
 
         public static Session CreateSession()
         {
-            // TODO add support for multiply sessions using different devices or emulators
-            return Sessions["AwesomeSession"];
+            // TODO add support for multiple sessions using different devices or emulators
+            if (currentSession != null)
+            {
+                Logger.Warn("Driver does not support multiple sessions!");
+                CloseSession(currentSession.SessionId);
+            }
+
+            currentSession = new Session("AwesomeSession");
+
+            return currentSession;
         }
 
         public static Session GetSessionbyId(string sessionId)
         {
-            return Sessions["AwesomeSession"];
+            return currentSession;
         }
 
         #endregion

--- a/Winium.StoreApps.Driver/Helpers/VsTestConsoleWrapper.cs
+++ b/Winium.StoreApps.Driver/Helpers/VsTestConsoleWrapper.cs
@@ -1,0 +1,97 @@
+﻿namespace Winium.StoreApps.Driver.Helpers
+{
+    #region
+
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+
+    #endregion
+
+    internal class VsTestConsoleWrapper : IDisposable
+    {
+        #region Constants
+
+        private const string CodedUiTestDllPath =
+            @"..\..\..\Winium.StoreApps.CodedUITestProject\bin\Debug\Winium.StoreApps.CodedUITestProject.dll";
+
+        #endregion
+
+        #region Fields
+
+        private readonly string deviceName;
+
+        private Process codedUiTestProcess;
+
+        #endregion
+
+        #region Constructors and Destructors
+
+        public VsTestConsoleWrapper(string deviceName)
+        {
+            this.deviceName = deviceName;
+        }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public void DeployCodedUiTestServer(bool captureCodedUiLogs)
+        {
+            var pathToVsTestconsole = ConfigurationManager.AppSettings["VsTestConsolePath"];
+
+            var runSettingsDoc = new RunSettings(this.deviceName);
+            var tempFilePath = Path.GetTempFileName();
+
+            runSettingsDoc.XmlDoc.Save(tempFilePath);
+
+            var arguments = new List<string>
+                                {
+                                    string.Format(CultureInfo.InvariantCulture, "\"{0}\"", CodedUiTestDllPath),
+                                    string.Format(CultureInfo.InvariantCulture, "/Settings:\"{0}\"", tempFilePath),
+                                    "/InIsolation"
+                                };
+            if (captureCodedUiLogs)
+            {
+                arguments.Add("/logger:trx");
+            }
+
+            // TODO We should generate run settings to specify device/emulator
+            var codedUiTestLoopPsi = new ProcessStartInfo
+                                         {
+                                             UseShellExecute = false, 
+                                             RedirectStandardError = true, 
+                                             RedirectStandardOutput = true, 
+                                             FileName = pathToVsTestconsole, 
+                                             Arguments = string.Join(" ", arguments)
+                                         };
+
+            this.codedUiTestProcess = new Process { StartInfo = codedUiTestLoopPsi };
+            this.codedUiTestProcess.OutputDataReceived += CaptureOutput;
+            this.codedUiTestProcess.ErrorDataReceived += CaptureOutput;
+            this.codedUiTestProcess.Start();
+            this.codedUiTestProcess.BeginOutputReadLine();
+        }
+
+        public void Dispose()
+        {
+            Logger.Debug(string.Format("Closing {0}", this.codedUiTestProcess.ProcessName));
+            this.codedUiTestProcess.CloseMainWindow();
+            this.codedUiTestProcess.Close();
+        }
+
+        #endregion
+
+        #region Methods
+
+        private static void CaptureOutput(object sender, DataReceivedEventArgs args)
+        {
+            Logger.Debug("VSTEST: {0}", args.Data);
+        }
+
+        #endregion
+    }
+}

--- a/Winium.StoreApps.Driver/Winium.StoreApps.Driver.csproj
+++ b/Winium.StoreApps.Driver/Winium.StoreApps.Driver.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="CommandExecutors\QuitExecutor.cs" />
     <Compile Include="CommandExecutors\StatusExecutor.cs" />
+    <Compile Include="Helpers\VsTestConsoleWrapper.cs" />
     <Compile Include="Helpers\BuildInfo.cs" />
     <Compile Include="Helpers\Capabilities.cs" />
     <Compile Include="CommandExecutors\CommandExecutorForward.cs" />


### PR DESCRIPTION
Add ability to capture CodedUi logs.

This prompted refactoring of sessions and vstestconsoel deployment.
- When new session is requested and current session is not terminated correctly with Quit, a warning will be logged and current session will be closed (with all its disposables, like vs.test.console), before creating new one (previously we reused some of session components without proper disposing).
- Added `debugCaptureLogs` capability of type Boolean, if set to `true`, CodedUi logs will be saved to `*.trx` file in `{DRIVER_WORKDIR}\TestResults\` on session termination (this would be useful for debugging of CodedUi server when combined with `Logger.LogMessage` in CodedUITestProject).
- `vs.test.console` deployement refactored into helper class and `IDisposable` implemented. On session is closed (by calling `Quit` or creating a new one) `vs.test.console` will be stopped and closed.  This helps with situation when we run tests without proper `Quit`. Still there is a possibility of `vs.test.console` not being closed when `Driver.exe` gets killed or quits unexpectedly.

**TODO**: research how to kill `vs.test.console` process if parent (`Driver.exe`) gets killed.

Also some ReSharper annotations were added to CodedUi server project. Driver needs same treatment.
